### PR TITLE
all: fix linting errors from golangci-lint v1.33.0

### DIFF
--- a/encryption/store.go
+++ b/encryption/store.go
@@ -23,7 +23,7 @@ import (
 //    b1, u6/u7/u8    => <e6/e7/e8, k8>
 //    b2, u1          => <e1', k1'>
 //
-// then the following lookups have outputs.
+// then the following lookups have outputs:
 //
 //    b1, u1          => <{e2:u2, e5:u5}, u1, nil>
 //    b1, u1/u2/u3    => <{e4:u4}, u1/u2/u3, <u1/u2/u3, e1/e2/e3, k3>>

--- a/encryption/store.go
+++ b/encryption/store.go
@@ -23,7 +23,7 @@ import (
 //    b1, u6/u7/u8    => <e6/e7/e8, k8>
 //    b2, u1          => <e1', k1'>
 //
-// Then the following lookups have outputs
+// then the following lookups have outputs.
 //
 //    b1, u1          => <{e2:u2, e5:u5}, u1, nil>
 //    b1, u1/u2/u3    => <{e4:u4}, u1/u2/u3, <u1/u2/u3, e1/e2/e3, k3>>

--- a/socket/dscp.go
+++ b/socket/dscp.go
@@ -9,7 +9,7 @@ package socket
 type dscp byte
 
 // See https://tools.ietf.org/html/rfc4594#section-2.3 for the definitions
-// of the below Differentiated Services Code Points
+// of the below Differentiated Services Code Points.
 //
 // nolint: deadcode,varcheck,unused
 const (

--- a/testcontext/compile.go
+++ b/testcontext/compile.go
@@ -71,7 +71,7 @@ func (ctx *Context) CompileWithLDFlagsX(pkg string, ldFlagsX map[string]string) 
 }
 
 // CompileShared compiles pkg as c-shared.
-// TODO: support inclusion from other directories
+// TODO: support inclusion from other directories.
 //  (cgo header paths are currently relative to package root)
 func (ctx *Context) CompileShared(t *testing.T, name string, pkg string) Include {
 	t.Helper()

--- a/testcontext/compile.go
+++ b/testcontext/compile.go
@@ -71,8 +71,9 @@ func (ctx *Context) CompileWithLDFlagsX(pkg string, ldFlagsX map[string]string) 
 }
 
 // CompileShared compiles pkg as c-shared.
+//
+// Note: cgo header paths are currently relative to package root.
 // TODO: support inclusion from other directories.
-//  (cgo header paths are currently relative to package root)
 func (ctx *Context) CompileShared(t *testing.T, name string, pkg string) Include {
 	t.Helper()
 

--- a/useragent/parse.go
+++ b/useragent/parse.go
@@ -270,18 +270,18 @@ func requireWhitespace(data []byte, from int) (next int, ok bool) {
 //                 / DIGIT / ALPHA
 //                 ; any VCHAR, except delimiters
 func istchar(b byte) bool {
-	// DIGIT / ALPHA.
+	// DIGIT / ALPHA
 	if '0' <= b && b <= '9' || 'a' <= b && b <= 'z' || 'A' <= b && b <= 'Z' {
 		return true
 	}
 
 	switch b {
-	// the set of symbols allowed.
+	// the set of symbols allowed
 	case '!', '#', '$', '%', '&', '\'', '*', '+', '-', '.', '^', '_', '`', '|', '~':
 		return true
 	}
 
-	// otherwise, just verify that it is visible.
+	// otherwise, just verify that it is visible
 	return isvchar(b) && !isdelim(b)
 }
 

--- a/useragent/parse.go
+++ b/useragent/parse.go
@@ -265,23 +265,23 @@ func requireWhitespace(data []byte, from int) (next int, ok bool) {
 	return next, true
 }
 
-// tchar           = "!" / "#" / "$" / "%" / "&" / "'" / "*"
-//                 / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~"
-//                 / DIGIT / ALPHA
-//                 ; any VCHAR, except delimiters
+// tchar           = "!" / "#" / "$" / "%" / "&" / "'" / "*",
+//                 / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~",
+//                 / DIGIT / ALPHA,
+//                 ; any VCHAR, except delimiters.
 func istchar(b byte) bool {
-	// DIGIT / ALPHA
+	// DIGIT / ALPHA.
 	if '0' <= b && b <= '9' || 'a' <= b && b <= 'z' || 'A' <= b && b <= 'Z' {
 		return true
 	}
 
 	switch b {
-	// the set of symbols allowed
+	// the set of symbols allowed.
 	case '!', '#', '$', '%', '&', '\'', '*', '+', '-', '.', '^', '_', '`', '|', '~':
 		return true
 	}
 
-	// otherwise, just verify that it is visible
+	// otherwise, just verify that it is visible.
 	return isvchar(b) && !isdelim(b)
 }
 

--- a/useragent/parse.go
+++ b/useragent/parse.go
@@ -265,10 +265,10 @@ func requireWhitespace(data []byte, from int) (next int, ok bool) {
 	return next, true
 }
 
-// tchar           = "!" / "#" / "$" / "%" / "&" / "'" / "*",
-//                 / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~",
-//                 / DIGIT / ALPHA,
-//                 ; any VCHAR, except delimiters.
+//   tchar         = "!" / "#" / "$" / "%" / "&" / "'" / "*"
+//                 / "+" / "-" / "." / "^" / "_" / "`" / "|" / "~"
+//                 / DIGIT / ALPHA
+//                 ; any VCHAR, except delimiters
 func istchar(b byte) bool {
 	// DIGIT / ALPHA.
 	if '0' <= b && b <= '9' || 'a' <= b && b <= 'z' || 'A' <= b && b <= 'Z' {


### PR DESCRIPTION
What: Fixes some linting errors. https://build.dev.storj.io/blue/organizations/jenkins/ci/detail/PR-22/1/pipeline/60

Why: We want to bump to v1.33.0 of golangci-lint.

## Code Review Checklist (to be filled out by reviewer)
 - [x] NEW: Are there any Satellite database migrations? Are they forwards _and_ backwards compatible? 
 - [x] Does the PR describe what changes are being made?
 - [x] Does the PR describe why the changes are being made?
 - [x] Does the code follow [our style guide](https://github.com/storj/docs/blob/master/code/Style.md)?
 - [x] Does the code follow [our testing guide](https://github.com/storj/docs/blob/master/code/Testing.md)?
 - [x] Is the PR appropriately sized? (If it could be broken into smaller PRs it should be)
 - [x] Does the new code have enough tests? (*every* PR should have tests or justification otherwise. Bug-fix PRs especially)
 - [x] Does the new code have enough documentation that answers "how do I use it?" and "what does it do?"? (both source documentation and [higher level](https://github.com/storj/docs), diagrams?)
 - [x] Does any documentation need updating?
 - [x] Do the database access patterns make sense?
 
