### PR TITLE
Add support for unencrypted object metadata

### DIFF
--- a/encryption/path_test.go
+++ b/encryption/path_test.go
@@ -20,7 +20,7 @@ import (
 
 func newStore(key storj.Key, pathCipher storj.CipherSuite) *Store {
 	store := NewStore()
-	if err := store.AddWithCipher("bucket", paths.Unencrypted{}, paths.Encrypted{}, key, pathCipher); err != nil {
+	if err := store.AddWithCipher("bucket", paths.Unencrypted{}, paths.Encrypted{}, key, pathCipher, storj.EncNull); err != nil {
 		panic(err)
 	}
 	return store
@@ -128,7 +128,7 @@ func TestStoreEncryption_BucketRoot(t *testing.T) {
 			if !assert.NoError(t, err, errTag) {
 				continue
 			}
-			err = bucketStore.AddWithCipher("bucket", paths.Unencrypted{}, paths.Encrypted{}, *bucketKey, cipher)
+			err = bucketStore.AddWithCipher("bucket", paths.Unencrypted{}, paths.Encrypted{}, *bucketKey, cipher, storj.EncNull)
 			if !assert.NoError(t, err, errTag) {
 				continue
 			}
@@ -187,7 +187,7 @@ func TestStoreEncryption_MultipleBases(t *testing.T) {
 					encPrefix, err := EncryptPath("bucket", prefix, cipher, rootStore)
 					require.NoError(t, err)
 
-					err = prefixStore.AddWithCipher("bucket", prefix, encPrefix, *prefixKey, cipher)
+					err = prefixStore.AddWithCipher("bucket", prefix, encPrefix, *prefixKey, cipher, storj.EncNull)
 					require.NoError(t, err)
 
 					path := paths.NewUnencrypted(rawPath)

--- a/encryption/store_test.go
+++ b/encryption/store_test.go
@@ -43,19 +43,27 @@ func abortIfError(err error) {
 	}
 }
 
+func forAllCipherPairs(test func(c1 storj.CipherSuite, c2 storj.CipherSuite)) {
+	forAllCiphers(func(c1 storj.CipherSuite) {
+		forAllCiphers(func(c2 storj.CipherSuite) {
+			test(c1, c2)
+		})
+	})
+}
+
 func ExampleStore() {
 	s := NewStore()
 	ep := paths.NewEncrypted
 	up := paths.NewUnencrypted
 
 	// Add a fairly complicated tree to the store.
-	abortIfError(s.AddWithCipher("b1", up("u1/u2/u3"), ep("e1/e2/e3"), toKey("k3"), storj.EncAESGCM))
-	abortIfError(s.AddWithCipher("b1", up("u1/u2/u3/u4"), ep("e1/e2/e3/e4"), toKey("k4"), storj.EncAESGCM))
-	abortIfError(s.AddWithCipher("b1", up("u1/u5"), ep("e1/e5"), toKey("k5"), storj.EncAESGCM))
-	abortIfError(s.AddWithCipher("b1", up("u6"), ep("e6"), toKey("k6"), storj.EncAESGCM))
-	abortIfError(s.AddWithCipher("b1", up("u6/u7/u8"), ep("e6/e7/e8"), toKey("k8"), storj.EncAESGCM))
-	abortIfError(s.AddWithCipher("b2", up("u1"), ep("e1'"), toKey("k1"), storj.EncAESGCM))
-	abortIfError(s.AddWithCipher("b3", paths.Unencrypted{}, paths.Encrypted{}, toKey("m1"), storj.EncAESGCM))
+	abortIfError(s.AddWithCipher("b1", up("u1/u2/u3"), ep("e1/e2/e3"), toKey("k3"), storj.EncAESGCM, storj.EncAESGCM))
+	abortIfError(s.AddWithCipher("b1", up("u1/u2/u3/u4"), ep("e1/e2/e3/e4"), toKey("k4"), storj.EncAESGCM, storj.EncAESGCM))
+	abortIfError(s.AddWithCipher("b1", up("u1/u5"), ep("e1/e5"), toKey("k5"), storj.EncAESGCM, storj.EncAESGCM))
+	abortIfError(s.AddWithCipher("b1", up("u6"), ep("e6"), toKey("k6"), storj.EncAESGCM, storj.EncAESGCM))
+	abortIfError(s.AddWithCipher("b1", up("u6/u7/u8"), ep("e6/e7/e8"), toKey("k8"), storj.EncAESGCM, storj.EncAESGCM))
+	abortIfError(s.AddWithCipher("b2", up("u1"), ep("e1'"), toKey("k1"), storj.EncAESGCM, storj.EncAESGCM))
+	abortIfError(s.AddWithCipher("b3", paths.Unencrypted{}, paths.Encrypted{}, toKey("m1"), storj.EncAESGCM, storj.EncAESGCM))
 
 	// Look up some complicated queries by the unencrypted path.
 	printLookup(s.LookupUnencrypted("b1", up("u1")))
@@ -107,7 +115,7 @@ func ExampleStore_SetDefaultKey() {
 	ep := paths.NewEncrypted
 	up := paths.NewUnencrypted
 
-	abortIfError(s.AddWithCipher("b1", up("u1/u2/u3"), ep("e1/e2/e3"), toKey("k3"), storj.EncAESGCM))
+	abortIfError(s.AddWithCipher("b1", up("u1/u2/u3"), ep("e1/e2/e3"), toKey("k3"), storj.EncAESGCM, storj.EncAESGCM))
 
 	printLookup(s.LookupUnencrypted("b1", up("u1")))
 	printLookup(s.LookupUnencrypted("b1", up("u1/u2")))
@@ -145,15 +153,15 @@ func TestStoreErrors(t *testing.T) {
 		up := paths.NewUnencrypted
 
 		// Too many encrypted parts
-		require.Error(t, s.AddWithCipher("b1", up("u1"), ep("e1/e2/e3"), storj.Key{}, pathCipher))
+		require.Error(t, s.AddWithCipher("b1", up("u1"), ep("e1/e2/e3"), storj.Key{}, pathCipher, storj.EncNull))
 
 		// Too many unencrypted parts
-		require.Error(t, s.AddWithCipher("b1", up("u1/u2/u3"), ep("e1"), storj.Key{}, pathCipher))
+		require.Error(t, s.AddWithCipher("b1", up("u1/u2/u3"), ep("e1"), storj.Key{}, pathCipher, storj.EncNull))
 
 		// Mismatches
-		require.NoError(t, s.AddWithCipher("b1", up("u1"), ep("e1"), storj.Key{}, pathCipher))
-		require.Error(t, s.AddWithCipher("b1", up("u2"), ep("e1"), storj.Key{}, pathCipher))
-		require.Error(t, s.AddWithCipher("b1", up("u1"), ep("f1"), storj.Key{}, pathCipher))
+		require.NoError(t, s.AddWithCipher("b1", up("u1"), ep("e1"), storj.Key{}, pathCipher, storj.EncNull))
+		require.Error(t, s.AddWithCipher("b1", up("u2"), ep("e1"), storj.Key{}, pathCipher, storj.EncNull))
+		require.Error(t, s.AddWithCipher("b1", up("u1"), ep("f1"), storj.Key{}, pathCipher, storj.EncNull))
 	}
 }
 
@@ -166,9 +174,9 @@ func TestStoreErrorState(t *testing.T) {
 	revealed1, consumed1, base1 := s.LookupUnencrypted("b1", up("u1/u2"))
 
 	// Attempt to do an addition that fails.
-	require.Error(t, s.AddWithCipher("b1", up("u1/u2"), ep("e1/e2/e3"), storj.Key{}, storj.EncNull))
-	require.Error(t, s.AddWithCipher("b1", up("u1/u2"), ep("e1/e2/e3"), storj.Key{}, storj.EncAESGCM))
-	require.Error(t, s.AddWithCipher("b1", up("u1/u2"), ep("e1/e2/e3"), storj.Key{}, storj.EncSecretBox))
+	require.Error(t, s.AddWithCipher("b1", up("u1/u2"), ep("e1/e2/e3"), storj.Key{}, storj.EncNull, storj.EncNull))
+	require.Error(t, s.AddWithCipher("b1", up("u1/u2"), ep("e1/e2/e3"), storj.Key{}, storj.EncAESGCM, storj.EncAESGCM))
+	require.Error(t, s.AddWithCipher("b1", up("u1/u2"), ep("e1/e2/e3"), storj.Key{}, storj.EncSecretBox, storj.EncSecretBox))
 
 	// Ensure that we get the same results as before
 	revealed2, consumed2, base2 := s.LookupUnencrypted("b1", up("u1/u2"))
@@ -180,18 +188,15 @@ func TestStoreErrorState(t *testing.T) {
 
 func TestStoreIterate(t *testing.T) {
 	type storeEntry struct {
-		bucket     string
-		unenc      paths.Unencrypted
-		enc        paths.Encrypted
-		key        storj.Key
-		pathCipher storj.CipherSuite
+		bucket         string
+		unenc          paths.Unencrypted
+		enc            paths.Encrypted
+		key            storj.Key
+		pathCipher     storj.CipherSuite
+		metadataCipher storj.CipherSuite
 	}
 
-	for _, pathCipher := range []storj.CipherSuite{
-		storj.EncNull,
-		storj.EncAESGCM,
-		storj.EncSecretBox,
-	} {
+	forAllCipherPairs(func(pathCipher storj.CipherSuite, metadataCipher storj.CipherSuite) {
 		for _, bypass := range []bool{false, true} {
 			s := NewStore()
 			s.EncryptionBypass = bypass
@@ -200,27 +205,27 @@ func TestStoreIterate(t *testing.T) {
 			up := paths.NewUnencrypted
 
 			expected := map[storeEntry]struct{}{
-				{"b1", up("u1/u2/u3"), ep("e1/e2/e3"), toKey("k3"), pathCipher}:         {},
-				{"b1", up("u1/u2/u3/u4"), ep("e1/e2/e3/e4"), toKey("k4"), pathCipher}:   {},
-				{"b1", up("u1/u5"), ep("e1/e5"), toKey("k5"), pathCipher}:               {},
-				{"b1", up("u6"), ep("e6"), toKey("k6"), pathCipher}:                     {},
-				{"b1", up("u6/u7/u8"), ep("e6/e7/e8"), toKey("k8"), pathCipher}:         {},
-				{"b2", up("u1"), ep("e1'"), toKey("k1"), pathCipher}:                    {},
-				{"b3", paths.Unencrypted{}, paths.Encrypted{}, toKey("m1"), pathCipher}: {},
+				{"b1", up("u1/u2/u3"), ep("e1/e2/e3"), toKey("k3"), pathCipher, metadataCipher}:         {},
+				{"b1", up("u1/u2/u3/u4"), ep("e1/e2/e3/e4"), toKey("k4"), pathCipher, metadataCipher}:   {},
+				{"b1", up("u1/u5"), ep("e1/e5"), toKey("k5"), pathCipher, metadataCipher}:               {},
+				{"b1", up("u6"), ep("e6"), toKey("k6"), pathCipher, metadataCipher}:                     {},
+				{"b1", up("u6/u7/u8"), ep("e6/e7/e8"), toKey("k8"), pathCipher, metadataCipher}:         {},
+				{"b2", up("u1"), ep("e1'"), toKey("k1"), pathCipher, metadataCipher}:                    {},
+				{"b3", paths.Unencrypted{}, paths.Encrypted{}, toKey("m1"), pathCipher, metadataCipher}: {},
 			}
 
 			for entry := range expected {
-				require.NoError(t, s.AddWithCipher(entry.bucket, entry.unenc, entry.enc, entry.key, entry.pathCipher))
+				require.NoError(t, s.AddWithCipher(entry.bucket, entry.unenc, entry.enc, entry.key, entry.pathCipher, entry.metadataCipher))
 			}
 
 			got := make(map[storeEntry]struct{})
-			require.NoError(t, s.IterateWithCipher(func(bucket string, unenc paths.Unencrypted, enc paths.Encrypted, key storj.Key, pathCipher storj.CipherSuite) error {
-				got[storeEntry{bucket, unenc, enc, key, pathCipher}] = struct{}{}
+			require.NoError(t, s.IterateWithCipher(func(bucket string, unenc paths.Unencrypted, enc paths.Encrypted, key storj.Key, pathCipher storj.CipherSuite, metadataCipher storj.CipherSuite) error {
+				got[storeEntry{bucket, unenc, enc, key, pathCipher, metadataCipher}] = struct{}{}
 				return nil
 			}))
 			require.Equal(t, expected, got)
 		}
-	}
+	})
 }
 
 func TestStoreEncryptionBypass(t *testing.T) {
@@ -248,6 +253,7 @@ func TestStoreClone(t *testing.T) {
 	store := NewStore()
 	store.SetDefaultKey(&defaultKey)
 	store.SetDefaultPathCipher(storj.EncAESGCM)
+	store.SetDefaultMetadataCipher(storj.EncAESGCM)
 	err := store.Add("bucket1", paths.NewUnencrypted("path1"), paths.NewEncrypted("encPath1"), pathKey)
 	require.NoError(t, err)
 
@@ -256,6 +262,7 @@ func TestStoreClone(t *testing.T) {
 	assert.Equal(t, store, clone)
 
 	assert.Equal(t, store.defaultPathCipher, clone.defaultPathCipher)
+	assert.Equal(t, store.defaultMetadataCipher, clone.defaultMetadataCipher)
 	assert.Equal(t, store.EncryptionBypass, clone.EncryptionBypass)
 
 	assert.NotSame(t, store.defaultKey, clone.defaultKey)

--- a/grant/internal/pb/encryption_access.pico.go
+++ b/grant/internal/pb/encryption_access.pico.go
@@ -15,6 +15,7 @@ type EncryptionAccess struct {
 	DefaultKey                  []byte                         `json:"default_key,omitempty"`
 	StoreEntries                []*EncryptionAccess_StoreEntry `json:"store_entries,omitempty"`
 	DefaultPathCipher           CipherSuite                    `json:"default_path_cipher,omitempty"`
+	DefaultMetadataCipher       CipherSuite                    `json:"default_metadata_cipher,omitempty"`
 	DefaultEncryptionParameters *EncryptionParameters          `json:"default_encryption_parameters,omitempty"`
 }
 
@@ -28,6 +29,7 @@ func (m *EncryptionAccess) Encode(c *picobuf.Encoder) bool {
 	}
 	c.Int32(3, (*int32)(&m.DefaultPathCipher))
 	c.Message(4, m.DefaultEncryptionParameters.Encode)
+	c.Int32(5, (*int32)(&m.DefaultMetadataCipher))
 	return true
 }
 
@@ -48,6 +50,7 @@ func (m *EncryptionAccess) Decode(c *picobuf.Decoder) {
 		}
 		m.DefaultEncryptionParameters.Decode(c)
 	})
+	c.Int32(5, (*int32)(&m.DefaultMetadataCipher))
 }
 
 type EncryptionAccess_StoreEntry struct {
@@ -56,6 +59,7 @@ type EncryptionAccess_StoreEntry struct {
 	EncryptedPath        []byte                `json:"encrypted_path,omitempty"`
 	Key                  []byte                `json:"key,omitempty"`
 	PathCipher           CipherSuite           `json:"path_cipher,omitempty"`
+	MetadataCipher       CipherSuite           `json:"metadata_cipher,omitempty"`
 	EncryptionParameters *EncryptionParameters `json:"encryption_parameters,omitempty"`
 }
 
@@ -69,6 +73,7 @@ func (m *EncryptionAccess_StoreEntry) Encode(c *picobuf.Encoder) bool {
 	c.Bytes(4, &m.Key)
 	c.Int32(5, (*int32)(&m.PathCipher))
 	c.Message(6, m.EncryptionParameters.Encode)
+	c.Int32(7, (*int32)(&m.MetadataCipher))
 	return true
 }
 
@@ -87,4 +92,5 @@ func (m *EncryptionAccess_StoreEntry) Decode(c *picobuf.Decoder) {
 		}
 		m.EncryptionParameters.Decode(c)
 	})
+	c.Int32(7, (*int32)(&m.MetadataCipher))
 }

--- a/pb/encryption_access.go
+++ b/pb/encryption_access.go
@@ -17,6 +17,7 @@ type encryptionAccessStoreEntryMarshal struct {
 	EncryptedPath        string                `json:"encrypted_path,omitempty"`
 	Key                  string                `json:"key,omitempty"`
 	PathCipher           CipherSuite           `json:"path_cipher,omitempty"`
+	MetadataCipher       CipherSuite           `json:"metadata_cipher,omitempty"`
 	EncryptionParameters *EncryptionParameters `json:"encryption_parameters,omitempty"`
 }
 
@@ -38,6 +39,7 @@ func (se *EncryptionAccess_StoreEntry) MarshalJSON() ([]byte, error) {
 		EncryptedPath:        path,
 		Key:                  base64.URLEncoding.EncodeToString(se.Key),
 		PathCipher:           se.PathCipher,
+		MetadataCipher:       se.MetadataCipher,
 		EncryptionParameters: se.EncryptionParameters,
 	})
 }

--- a/pb/encryption_access.pb.go
+++ b/pb/encryption_access.pb.go
@@ -17,6 +17,7 @@ type EncryptionAccess struct {
 	DefaultKey                  []byte                         `protobuf:"bytes,1,opt,name=default_key,json=defaultKey,proto3" json:"default_key,omitempty"`
 	StoreEntries                []*EncryptionAccess_StoreEntry `protobuf:"bytes,2,rep,name=store_entries,json=storeEntries,proto3" json:"store_entries,omitempty"`
 	DefaultPathCipher           CipherSuite                    `protobuf:"varint,3,opt,name=default_path_cipher,json=defaultPathCipher,proto3,enum=encryption.CipherSuite" json:"default_path_cipher,omitempty"`
+	DefaultMetadataCipher       CipherSuite                    `protobuf:"varint,5,opt,name=default_metadata_cipher,json=defaultMetadataCipher,proto3,enum=encryption.CipherSuite" json:"default_metadata_cipher,omitempty"`
 	DefaultEncryptionParameters *EncryptionParameters          `protobuf:"bytes,4,opt,name=default_encryption_parameters,json=defaultEncryptionParameters,proto3" json:"default_encryption_parameters,omitempty"`
 	XXX_NoUnkeyedLiteral        struct{}                       `json:"-"`
 	XXX_unrecognized            []byte                         `json:"-"`
@@ -66,6 +67,13 @@ func (m *EncryptionAccess) GetDefaultPathCipher() CipherSuite {
 	return CipherSuite_ENC_UNSPECIFIED
 }
 
+func (m *EncryptionAccess) GetDefaultMetadataCipher() CipherSuite {
+	if m != nil {
+		return m.DefaultMetadataCipher
+	}
+	return CipherSuite_ENC_UNSPECIFIED
+}
+
 func (m *EncryptionAccess) GetDefaultEncryptionParameters() *EncryptionParameters {
 	if m != nil {
 		return m.DefaultEncryptionParameters
@@ -79,6 +87,7 @@ type EncryptionAccess_StoreEntry struct {
 	EncryptedPath        []byte                `protobuf:"bytes,3,opt,name=encrypted_path,json=encryptedPath,proto3" json:"encrypted_path,omitempty"`
 	Key                  []byte                `protobuf:"bytes,4,opt,name=key,proto3" json:"key,omitempty"`
 	PathCipher           CipherSuite           `protobuf:"varint,5,opt,name=path_cipher,json=pathCipher,proto3,enum=encryption.CipherSuite" json:"path_cipher,omitempty"`
+	MetadataCipher       CipherSuite           `protobuf:"varint,7,opt,name=metadata_cipher,json=metadataCipher,proto3,enum=encryption.CipherSuite" json:"metadata_cipher,omitempty"`
 	EncryptionParameters *EncryptionParameters `protobuf:"bytes,6,opt,name=encryption_parameters,json=encryptionParameters,proto3" json:"encryption_parameters,omitempty"`
 	XXX_NoUnkeyedLiteral struct{}              `json:"-"`
 	XXX_unrecognized     []byte                `json:"-"`
@@ -138,6 +147,13 @@ func (m *EncryptionAccess_StoreEntry) GetKey() []byte {
 func (m *EncryptionAccess_StoreEntry) GetPathCipher() CipherSuite {
 	if m != nil {
 		return m.PathCipher
+	}
+	return CipherSuite_ENC_UNSPECIFIED
+}
+
+func (m *EncryptionAccess_StoreEntry) GetMetadataCipher() CipherSuite {
+	if m != nil {
+		return m.MetadataCipher
 	}
 	return CipherSuite_ENC_UNSPECIFIED
 }

--- a/pb/encryption_access.proto
+++ b/pb/encryption_access.proto
@@ -17,11 +17,13 @@ message EncryptionAccess {
         bytes key = 4;
 
         encryption.CipherSuite path_cipher = 5;
+        encryption.CipherSuite metadata_cipher = 7;
         encryption.EncryptionParameters encryption_parameters = 6;
     }
 
     bytes default_key = 1;
     repeated StoreEntry store_entries = 2;
     encryption.CipherSuite default_path_cipher = 3;
+    encryption.CipherSuite default_metadata_cipher = 5;
     encryption.EncryptionParameters default_encryption_parameters = 4;
 }

--- a/pb/json_test.go
+++ b/pb/json_test.go
@@ -25,8 +25,9 @@ func TestMarshalJSON(t *testing.T) {
 			EncryptedPath:   []byte("enc"),
 			Key:             []byte("key"),
 			PathCipher:      CipherSuite_ENC_AESGCM,
+			MetadataCipher:  CipherSuite_ENC_AESGCM,
 		})
 		require.NoError(t, err)
-		require.Equal(t, string(bs), `{"bucket":"bucket","unencrypted_path":"unenc","encrypted_path":"ZW5j","key":"a2V5","path_cipher":"ENC_AESGCM"}`)
+		require.Equal(t, string(bs), `{"bucket":"bucket","unencrypted_path":"unenc","encrypted_path":"ZW5j","key":"a2V5","path_cipher":"ENC_AESGCM","metadata_cipher":"ENC_AESGCM"}`)
 	})
 }

--- a/pb/metainfo.pb.go
+++ b/pb/metainfo.pb.go
@@ -1522,6 +1522,7 @@ type Object struct {
 	EncryptedMetadataNonce        Nonce         `protobuf:"bytes,9,opt,name=encrypted_metadata_nonce,json=encryptedMetadataNonce,proto3,customtype=Nonce" json:"encrypted_metadata_nonce"`
 	EncryptedMetadata             []byte        `protobuf:"bytes,10,opt,name=encrypted_metadata,json=encryptedMetadata,proto3" json:"encrypted_metadata,omitempty"`
 	EncryptedMetadataEncryptedKey []byte        `protobuf:"bytes,17,opt,name=encrypted_metadata_encrypted_key,json=encryptedMetadataEncryptedKey,proto3" json:"encrypted_metadata_encrypted_key,omitempty"`
+	ClearMetadata                 []byte        `protobuf:"bytes,22,opt,name=clear_metadata,json=clearMetadata,proto3" json:"clear_metadata,omitempty"`
 	// fixed_segment_size is 0 for migrated objects.
 	FixedSegmentSize     int64                 `protobuf:"varint,11,opt,name=fixed_segment_size,json=fixedSegmentSize,proto3" json:"fixed_segment_size,omitempty"`
 	RedundancyScheme     *RedundancyScheme     `protobuf:"bytes,12,opt,name=redundancy_scheme,json=redundancyScheme,proto3" json:"redundancy_scheme,omitempty"`
@@ -1635,6 +1636,13 @@ func (m *Object) GetEncryptedMetadataEncryptedKey() []byte {
 	return nil
 }
 
+func (m *Object) GetClearMetadata() []byte {
+	if m != nil {
+		return m.ClearMetadata
+	}
+	return nil
+}
+
 func (m *Object) GetFixedSegmentSize() int64 {
 	if m != nil {
 		return m.FixedSegmentSize
@@ -1709,6 +1717,7 @@ type BeginObjectRequest struct {
 	EncryptedMetadataNonce        Nonce                 `protobuf:"bytes,9,opt,name=encrypted_metadata_nonce,json=encryptedMetadataNonce,proto3,customtype=Nonce" json:"encrypted_metadata_nonce"`
 	EncryptedMetadata             []byte                `protobuf:"bytes,10,opt,name=encrypted_metadata,json=encryptedMetadata,proto3" json:"encrypted_metadata,omitempty"`
 	EncryptedMetadataEncryptedKey []byte                `protobuf:"bytes,11,opt,name=encrypted_metadata_encrypted_key,json=encryptedMetadataEncryptedKey,proto3" json:"encrypted_metadata_encrypted_key,omitempty"`
+	ClearMetadata                 []byte                `protobuf:"bytes,16,opt,name=clear_metadata,json=clearMetadata,proto3" json:"clear_metadata,omitempty"`
 	Retention                     *Retention            `protobuf:"bytes,12,opt,name=retention,proto3" json:"retention,omitempty"`
 	LegalHold                     bool                  `protobuf:"varint,13,opt,name=legal_hold,json=legalHold,proto3" json:"legal_hold,omitempty"`
 	XXX_NoUnkeyedLiteral          struct{}              `json:"-"`
@@ -1797,6 +1806,13 @@ func (m *BeginObjectRequest) GetEncryptedMetadata() []byte {
 func (m *BeginObjectRequest) GetEncryptedMetadataEncryptedKey() []byte {
 	if m != nil {
 		return m.EncryptedMetadataEncryptedKey
+	}
+	return nil
+}
+
+func (m *BeginObjectRequest) GetClearMetadata() []byte {
+	if m != nil {
+		return m.ClearMetadata
 	}
 	return nil
 }
@@ -1895,6 +1911,7 @@ type CommitObjectRequest struct {
 	EncryptedMetadataNonce        Nonce    `protobuf:"bytes,2,opt,name=encrypted_metadata_nonce,json=encryptedMetadataNonce,proto3,customtype=Nonce" json:"encrypted_metadata_nonce"`
 	EncryptedMetadata             []byte   `protobuf:"bytes,3,opt,name=encrypted_metadata,json=encryptedMetadata,proto3" json:"encrypted_metadata,omitempty"`
 	EncryptedMetadataEncryptedKey []byte   `protobuf:"bytes,4,opt,name=encrypted_metadata_encrypted_key,json=encryptedMetadataEncryptedKey,proto3" json:"encrypted_metadata_encrypted_key,omitempty"`
+	ClearMetadata                 []byte   `protobuf:"bytes,16,opt,name=clear_metadata,json=clearMetadata,proto3" json:"clear_metadata,omitempty"`
 	XXX_NoUnkeyedLiteral          struct{} `json:"-"`
 	XXX_unrecognized              []byte   `json:"-"`
 	XXX_sizecache                 int32    `json:"-"`
@@ -1946,6 +1963,13 @@ func (m *CommitObjectRequest) GetEncryptedMetadata() []byte {
 func (m *CommitObjectRequest) GetEncryptedMetadataEncryptedKey() []byte {
 	if m != nil {
 		return m.EncryptedMetadataEncryptedKey
+	}
+	return nil
+}
+
+func (m *CommitObjectRequest) GetClearMetadata() []byte {
+	if m != nil {
+		return m.ClearMetadata
 	}
 	return nil
 }
@@ -2772,6 +2796,7 @@ type ObjectListItem struct {
 	EncryptedMetadataNonce        Nonce         `protobuf:"bytes,7,opt,name=encrypted_metadata_nonce,json=encryptedMetadataNonce,proto3,customtype=Nonce" json:"encrypted_metadata_nonce"`
 	EncryptedMetadataEncryptedKey []byte        `protobuf:"bytes,11,opt,name=encrypted_metadata_encrypted_key,json=encryptedMetadataEncryptedKey,proto3" json:"encrypted_metadata_encrypted_key,omitempty"`
 	EncryptedMetadata             []byte        `protobuf:"bytes,8,opt,name=encrypted_metadata,json=encryptedMetadata,proto3" json:"encrypted_metadata,omitempty"`
+	ClearMetadata                 []byte        `protobuf:"bytes,14,opt,name=clear_metadata,json=clearMetadata,proto3" json:"clear_metadata,omitempty"`
 	// plain_size is 0 for migrated objects.
 	PlainSize            int64     `protobuf:"varint,10,opt,name=plain_size,json=plainSize,proto3" json:"plain_size,omitempty"`
 	StreamId             *StreamID `protobuf:"bytes,9,opt,name=stream_id,json=streamId,proto3,customtype=StreamID" json:"stream_id,omitempty"`
@@ -2868,6 +2893,13 @@ func (m *ObjectListItem) GetEncryptedMetadataEncryptedKey() []byte {
 func (m *ObjectListItem) GetEncryptedMetadata() []byte {
 	if m != nil {
 		return m.EncryptedMetadata
+	}
+	return nil
+}
+
+func (m *ObjectListItem) GetClearMetadata() []byte {
+	if m != nil {
+		return m.ClearMetadata
 	}
 	return nil
 }
@@ -3259,6 +3291,7 @@ type UpdateObjectMetadataRequest struct {
 	EncryptedMetadataNonce        Nonce          `protobuf:"bytes,4,opt,name=encrypted_metadata_nonce,json=encryptedMetadataNonce,proto3,customtype=Nonce" json:"encrypted_metadata_nonce"`
 	EncryptedMetadata             []byte         `protobuf:"bytes,5,opt,name=encrypted_metadata,json=encryptedMetadata,proto3" json:"encrypted_metadata,omitempty"`
 	EncryptedMetadataEncryptedKey []byte         `protobuf:"bytes,6,opt,name=encrypted_metadata_encrypted_key,json=encryptedMetadataEncryptedKey,proto3" json:"encrypted_metadata_encrypted_key,omitempty"`
+	ClearMetadata                 []byte         `protobuf:"bytes,16,opt,name=clear_metadata,json=clearMetadata,proto3" json:"clear_metadata,omitempty"`
 	XXX_NoUnkeyedLiteral          struct{}       `json:"-"`
 	XXX_unrecognized              []byte         `json:"-"`
 	XXX_sizecache                 int32          `json:"-"`
@@ -3331,6 +3364,13 @@ func (m *UpdateObjectMetadataRequest) GetEncryptedMetadata() []byte {
 func (m *UpdateObjectMetadataRequest) GetEncryptedMetadataEncryptedKey() []byte {
 	if m != nil {
 		return m.EncryptedMetadataEncryptedKey
+	}
+	return nil
+}
+
+func (m *UpdateObjectMetadataRequest) GetClearMetadata() []byte {
+	if m != nil {
+		return m.ClearMetadata
 	}
 	return nil
 }
@@ -6694,6 +6734,7 @@ type FinishCopyObjectRequest struct {
 	NewEncryptedMetadata         []byte                  `protobuf:"bytes,7,opt,name=new_encrypted_metadata,json=newEncryptedMetadata,proto3" json:"new_encrypted_metadata,omitempty"`
 	NewEncryptedMetadataKeyNonce Nonce                   `protobuf:"bytes,4,opt,name=new_encrypted_metadata_key_nonce,json=newEncryptedMetadataKeyNonce,proto3,customtype=Nonce" json:"new_encrypted_metadata_key_nonce"`
 	NewEncryptedMetadataKey      []byte                  `protobuf:"bytes,5,opt,name=new_encrypted_metadata_key,json=newEncryptedMetadataKey,proto3" json:"new_encrypted_metadata_key,omitempty"`
+	NewClearMetadata             []byte                  `protobuf:"bytes,16,opt,name=new_clear_metadata,json=newClearMetadata,proto3" json:"new_clear_metadata,omitempty"`
 	NewSegmentKeys               []*EncryptedKeyAndNonce `protobuf:"bytes,6,rep,name=new_segment_keys,json=newSegmentKeys,proto3" json:"new_segment_keys,omitempty"`
 	XXX_NoUnkeyedLiteral         struct{}                `json:"-"`
 	XXX_unrecognized             []byte                  `json:"-"`
@@ -6781,6 +6822,13 @@ func (m *FinishCopyObjectRequest) GetNewEncryptedMetadata() []byte {
 func (m *FinishCopyObjectRequest) GetNewEncryptedMetadataKey() []byte {
 	if m != nil {
 		return m.NewEncryptedMetadataKey
+	}
+	return nil
+}
+
+func (m *FinishCopyObjectRequest) GetNewClearMetadata() []byte {
+	if m != nil {
+		return m.NewClearMetadata
 	}
 	return nil
 }

--- a/pb/metainfo.proto
+++ b/pb/metainfo.proto
@@ -301,6 +301,7 @@ message Object {
     bytes encrypted_metadata_nonce         = 9 [(gogoproto.customtype) = "Nonce", (gogoproto.nullable) = false];
     bytes encrypted_metadata               = 10;
     bytes encrypted_metadata_encrypted_key = 17;
+    bytes clear_metadata                   = 22;
 
     // fixed_segment_size is 0 for migrated objects.
     int64                           fixed_segment_size    = 11;
@@ -337,6 +338,7 @@ message BeginObjectRequest {
     bytes encrypted_metadata_nonce = 9 [(gogoproto.customtype) = "Nonce", (gogoproto.nullable) = false];
     bytes encrypted_metadata = 10;
     bytes encrypted_metadata_encrypted_key = 11;
+    bytes clear_metadata = 16;
 
     Retention retention = 12;
     bool legal_hold = 13;
@@ -366,6 +368,7 @@ message CommitObjectRequest {
     bytes encrypted_metadata_nonce = 2 [(gogoproto.customtype) = "Nonce", (gogoproto.nullable) = false];
     bytes encrypted_metadata = 3; // TODO: set maximum size limit
     bytes encrypted_metadata_encrypted_key = 4;
+    bytes clear_metadata = 16;
 }
 
 message CommitObjectResponse {
@@ -526,6 +529,7 @@ message ObjectListItem {
     bytes encrypted_metadata_nonce = 7 [(gogoproto.customtype) = "Nonce", (gogoproto.nullable) = false];
     bytes encrypted_metadata_encrypted_key = 11;
     bytes encrypted_metadata       = 8;
+    bytes clear_metadata = 14;
 
     // plain_size is 0 for migrated objects.
     int64 plain_size = 10;
@@ -597,6 +601,7 @@ message UpdateObjectMetadataRequest {
     bytes encrypted_metadata_nonce = 4 [(gogoproto.customtype) = "Nonce", (gogoproto.nullable) = false];
     bytes encrypted_metadata = 5; // TODO: set maximum size limit
     bytes encrypted_metadata_encrypted_key = 6;
+    bytes clear_metadata = 16;
 }
 
 message UpdateObjectMetadataResponse {
@@ -1070,6 +1075,7 @@ message FinishCopyObjectRequest {
     bytes new_encrypted_metadata = 7;
     bytes new_encrypted_metadata_key_nonce = 4 [(gogoproto.customtype) = "Nonce", (gogoproto.nullable) = false];
     bytes new_encrypted_metadata_key = 5;
+    bytes new_clear_metadata = 16;
     repeated EncryptedKeyAndNonce new_segment_keys = 6;
 }
 

--- a/proto.lock
+++ b/proto.lock
@@ -2675,6 +2675,11 @@
                 "type": "bytes"
               },
               {
+                "id": 22,
+                "name": "clear_metadata",
+                "type": "bytes"
+              },
+              {
                 "id": 11,
                 "name": "fixed_segment_size",
                 "type": "int64"
@@ -2795,6 +2800,11 @@
                 "type": "bytes"
               },
               {
+                "id": 16,
+                "name": "clear_metadata",
+                "type": "bytes"
+              },
+              {
                 "id": 12,
                 "name": "retention",
                 "type": "Retention"
@@ -2902,6 +2912,11 @@
               {
                 "id": 4,
                 "name": "encrypted_metadata_encrypted_key",
+                "type": "bytes"
+              },
+              {
+                "id": 16,
+                "name": "clear_metadata",
                 "type": "bytes"
               }
             ]
@@ -3301,6 +3316,11 @@
                 "type": "bytes"
               },
               {
+                "id": 14,
+                "name": "clear_metadata",
+                "type": "bytes"
+              },
+              {
                 "id": 10,
                 "name": "plain_size",
                 "type": "int64"
@@ -3568,6 +3588,11 @@
               {
                 "id": 6,
                 "name": "encrypted_metadata_encrypted_key",
+                "type": "bytes"
+              },
+              {
+                "id": 16,
+                "name": "clear_metadata",
                 "type": "bytes"
               }
             ]
@@ -5409,6 +5434,11 @@
               {
                 "id": 5,
                 "name": "new_encrypted_metadata_key",
+                "type": "bytes"
+              },
+              {
+                "id": 16,
+                "name": "new_clear_metadata",
                 "type": "bytes"
               },
               {

--- a/proto.lock
+++ b/proto.lock
@@ -607,6 +607,11 @@
                 "type": "encryption.CipherSuite"
               },
               {
+                "id": 5,
+                "name": "default_metadata_cipher",
+                "type": "encryption.CipherSuite"
+              },
+              {
                 "id": 4,
                 "name": "default_encryption_parameters",
                 "type": "encryption.EncryptionParameters"
@@ -639,6 +644,11 @@
                   {
                     "id": 5,
                     "name": "path_cipher",
+                    "type": "encryption.CipherSuite"
+                  },
+                  {
+                    "id": 7,
+                    "name": "metadata_cipher",
                     "type": "encryption.CipherSuite"
                   },
                   {

--- a/usermeta/usermeta.go
+++ b/usermeta/usermeta.go
@@ -1,0 +1,64 @@
+// Copyright (C) 2025 Storj Labs, Inc.
+// See LICENSE for copying information.
+
+package usermeta
+
+import (
+	"encoding/json"
+
+	"storj.io/common/pb"
+)
+
+type UserMeta map[string]string
+
+// Marshal user metadata payload using the SerializableMeta structure.
+func Marshal(meta UserMeta) ([]byte, error) {
+	m := &pb.SerializableMeta{
+		UserDefined: meta,
+	}
+
+	return pb.Marshal(m)
+}
+
+// Marshal a JSON-encoded user metadata using the SerializableMeta structure.
+func MarshalJSON(meta string) ([]byte, error) {
+	var m UserMeta
+	err := json.Unmarshal([]byte(meta), &m)
+	if err != nil {
+		return nil, err
+	}
+
+	return Marshal(m)
+}
+
+// Unmarshal user metadata payload using the SerializableMeta structure.
+func Unmarshal(data []byte) (UserMeta, error) {
+	m := new(pb.SerializableMeta)
+	err := pb.Unmarshal(data, m)
+	if err != nil {
+		return nil, err
+	}
+
+	return m.UserDefined, nil
+}
+
+// UnmarshalJSON unmarshals the user metadata payload and returns it as a JSON string.
+func UnmarshalJSON(data []byte) (string, error) {
+	meta, err := Unmarshal(data)
+	if err != nil {
+		return "", err
+	}
+
+	j, err := json.Marshal(meta)
+	if err != nil {
+		return "", err
+	}
+
+	return string(j), nil
+}
+
+// Valid checks if the data is a valid user metadata payload.
+func Valid(data []byte) bool {
+	_, err := Unmarshal(data)
+	return err == nil
+}

--- a/usermeta/usermeta_test.go
+++ b/usermeta/usermeta_test.go
@@ -35,3 +35,23 @@ func TestUserMetaMarshalJSON(t *testing.T) {
 
 	require.Equal(t, meta, meta2)
 }
+
+func TestDeepUserMeta(t *testing.T) {
+	deepMeta := DeepUserMeta{
+		"s": "text",
+		"o": map[string]interface{}{
+			"a": []interface{}{1.0, 2.0, 3.0},
+		},
+	}
+
+	meta, err := deepMeta.toUserMeta()
+	require.NoError(t, err)
+	require.Equal(t, UserMeta{
+		"s":      "text",
+		"json:o": `{"a":[1,2,3]}`,
+	}, meta)
+
+	deepMeta2, err := meta.toDeepUserMeta()
+	require.NoError(t, err)
+	require.Equal(t, deepMeta, deepMeta2)
+}

--- a/usermeta/usermeta_test.go
+++ b/usermeta/usermeta_test.go
@@ -1,0 +1,37 @@
+// Copyright (C) 2025 Storj Labs, Inc.
+// See LICENSE for copying information.
+
+package usermeta
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestUserMetaMarshal(t *testing.T) {
+	meta := UserMeta{
+		"key1": "value1",
+		"key2": "value2",
+	}
+
+	data, err := Marshal(meta)
+	require.NoError(t, err)
+
+	meta2, err := Unmarshal(data)
+	require.NoError(t, err)
+
+	require.Equal(t, meta, meta2)
+}
+
+func TestUserMetaMarshalJSON(t *testing.T) {
+	meta := `{"foo":"bar"}`
+
+	data, err := MarshalJSON(meta)
+	require.NoError(t, err)
+
+	meta2, err := UnmarshalJSON(data)
+	require.NoError(t, err)
+
+	require.Equal(t, meta, meta2)
+}


### PR DESCRIPTION
This PR implements the necessary changes for the searchable metadata feature:

1. Added metadata cipher field to access grants. Metadata encryption can be enabled/disabled per folder, just as path encryption.
2. Added clear (unencrypted) metadata field to several protobuf structures. I was thinking about sending the clear metadata in the `encrypted_metadata` field (just as for paths), but it would cause existing clients to fail without a metadata encryption key. So it was more modification in the common repository, but more backwards compatible.
3. Added a new `usermeta` package that converts deeply structured JSON from/to serializable metadata. For compatibility reasons, deep metadata structures are supported in the application layer: metadata object `{"s":"text","o":[1,2,3]"}` are sent as `map[string]string` in the form of `{"s":"text","json:o":"[1,2,3]"}`. It is the responsibility of satellite and the client application to encode/decode these shallow JSONs using the `usermeta` package.